### PR TITLE
docker: ignore configuration files (yml/edn) build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+moclojer.yml
+moclojer.edn
+test/
+.git
+.gitignore
+.dockerignore
+README.md
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,6 @@ pom.xml.asc
 
 ## moclojer
 /moclojer
-/*.yaml
-/*.yml
+!moclojer.[yml, edn]
+*.[yaml, yml, edn]*
 .socket-repl-port

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,7 @@ pom.xml.asc
 ## moclojer
 /moclojer
 !moclojer.[yml, edn]
-*.[yaml, yml, edn]*
+*.yaml
+*.yml
+*.edn
 .socket-repl-port

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM docker.io/clojure:openjdk-11-tools-deps-slim-buster AS jar
 WORKDIR /app
 COPY . .
-RUN clojure -A:dev -M --report stderr -m moclojer.build && \
-    rm /app/moclojer.yml /app/moclojer.edn
+RUN clojure -A:dev -M --report stderr -m moclojer.build
 ENV PORT="8000"
 ENV HOST="0.0.0.0"
 ENV CONFIG="/app/moclojer.yml"


### PR DESCRIPTION
the container must not have a default configuration file, when you
up running moclojer via docker you must always mount volume with the
configuration file