### PR TITLE
Using multistage to smaller docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
-FROM docker.io/clojure:openjdk-19-tools-deps-slim-bullseye
+FROM docker.io/clojure:openjdk-19-tools-deps-slim-bullseye AS build
 WORKDIR /app
+COPY deps.edn .
+RUN clojure -P && clojure -A:dev -P
 COPY . .
 RUN clojure -A:dev -M --report stderr -m moclojer.build
+
+FROM docker.io/openjdk:19-jdk-alpine
+WORKDIR /app
+COPY --from=build /app/target/moclojer.jar .
 ENV PORT="8000"
 ENV HOST="0.0.0.0"
 ENV CONFIG="/app/moclojer.yml"
 EXPOSE ${PORT}
 VOLUME ${CONFIG}
-CMD ["java", "-jar", "target/moclojer.jar"]
+CMD ["java", "-jar", "moclojer.jar"]


### PR DESCRIPTION
Before: 662MB
After: 349MB

Possible optimizations:
- Use native-image and from scratch images
- Remove source and unnecessary files from the JAR