### PR TITLE
WIP: feat(log): add support to export logs to file

### DIFF
--- a/src/com/moclojer/config.clj
+++ b/src/com/moclojer/config.clj
@@ -36,6 +36,9 @@
                 :desc    "Log output format."
                 :alias   :l
                 :default "default"}
+   :log-file {:ref     "<file>"
+              :desc    "Log file path to save logs."
+              :alias   :f}
    :help    {:desc   "Show this Help."
              :alias  :h}})
 


### PR DESCRIPTION
Add support to export logs to file using the `--log-file` flag or `-f` flag. This feature allows users to save logs to a specified file path while maintaining the existing console output. The implementation includes:

- New CLI option for log file path
- File appender configuration in logging system
- Concurrent logging to both console and file when enabled

fixed: #307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added file logging support, enabling users to set a custom log file path for saving logs.
  - Enhanced the logging configuration to optionally include file-based log output for improved log management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->