### PR TITLE
Add Postman Collection v2.1 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,9 @@ This file provides guidance to AI coding assistants (Claude Code, Cursor, GitHub
 
 ## Project Overview
 
-Moclojer is an HTTP mock server written in Clojure that generates mock APIs from YAML, EDN, or OpenAPI specifications. It supports both HTTP endpoints and WebSocket connections.
+Moclojer is an HTTP mock server written in Clojure that generates mock APIs from YAML, EDN, OpenAPI, or Postman Collection specifications. It supports both HTTP endpoints and WebSocket connections.
+
+**⚠️ IMPORTANT: Code changes REQUIRE documentation updates!** See [Documentation Requirements](#documentation-requirements) section.
 
 ## Development Commands
 
@@ -37,13 +39,14 @@ clj -X:deploy-clojars
 
 1. **Entry Point** (`com.moclojer.core`): CLI parsing via babashka.cli, loads config and starts server
 2. **Adapters** (`com.moclojer.adapters`): Transforms CLI args/env into config, generates routes from config
-3. **Router** (`com.moclojer.router`): Smart router that detects spec type (moclojer vs OpenAPI) and delegates
+3. **Router** (`com.moclojer.router`): Smart router that detects spec type (moclojer vs OpenAPI vs Postman) and delegates
 4. **Server** (`com.moclojer.server`): http-kit server with reitit router, includes file watcher for hot reload
 
 ### Spec Processing
 
 - **`com.moclojer.specs.moclojer`**: Converts moclojer YAML/EDN spec to reitit routes. Handles HTTP endpoints, WebSocket endpoints, template rendering (Selmer), and webhooks
 - **`com.moclojer.specs.openapi`**: Converts OpenAPI v3 spec to moclojer format (path conversion: `{id}` -> `:id`)
+- **`com.moclojer.specs.postman`**: Converts Postman Collection v2.1 to moclojer format. Processes nested folders, extracts response examples, converts path variables
 
 ### Key Components
 
@@ -107,6 +110,95 @@ Tests are in `test/com/moclojer/`. Resource files for tests are in `test/com/moc
 - **New external-body provider**: add in `com.moclojer.external-body/`, update `type-identification`
 - **New middleware**: add in `com.moclojer.middleware/`, register in `server.clj` middleware chain
 
+## Documentation Requirements
+
+**CRITICAL: Always update documentation when making changes!**
+
+### When to Update Documentation
+
+Update documentation in `docs/` for ANY of these changes:
+
+1. **New Features**
+   - Add tutorial/guide in `docs/getting-started/` or `docs/advanced/`
+   - Update `docs/SUMMARY.md` to include new page
+   - Update `docs/README.md` if it affects learning path
+   - Add examples in `examples/` directory
+
+2. **New Configuration Options**
+   - Update `docs/reference/configuration-spec.md`
+   - Add examples in relevant tutorial pages
+   - Update CLI reference if applicable
+
+3. **API Changes**
+   - Update affected tutorial pages
+   - Update troubleshooting guide if needed
+   - Add migration notes in release notes
+
+4. **Bug Fixes**
+   - Update FAQ if it's a common issue
+   - Update troubleshooting guide
+   - Add to release notes
+
+### Documentation Checklist
+
+When adding a new feature (like Postman Collection support):
+
+- [ ] Create detailed guide in `docs/getting-started/` or `docs/advanced/`
+- [ ] Add entry to `docs/SUMMARY.md`
+- [ ] Update `docs/README.md` (getting started section)
+- [ ] Update `docs/getting-started/overview.md` (mentions + examples)
+- [ ] Update main `README.md` (project root)
+- [ ] Update `CLAUDE.md` (this file) with technical details
+- [ ] Add example files to `examples/` directory
+- [ ] Create `examples/README.md` if needed
+- [ ] Add to release notes in `docs/releases/next.md`
+
+### Documentation Structure
+
+```
+docs/
+├── README.md              # Main docs entry, learning paths
+├── SUMMARY.md             # Table of contents for all docs
+├── getting-started/       # Beginner tutorials (progressive)
+│   ├── overview.md        # What is moclojer? Why use it?
+│   ├── installation.md    # Getting moclojer installed
+│   ├── postman-collections.md  # Using Postman Collections
+│   ├── your-first-mock.md # First YAML mock tutorial
+│   └── ...
+├── advanced/              # Advanced features
+│   ├── websocket-support.md
+│   ├── external-bodies.md
+│   └── ...
+├── reference/             # Technical reference
+│   ├── configuration-spec.md
+│   ├── faq.md
+│   └── ...
+└── releases/              # Release notes
+    ├── next.md            # Unreleased changes
+    └── v*.md              # Version releases
+```
+
+### Documentation Style Guide
+
+- **Write for beginners** - Assume no prior moclojer knowledge
+- **Use progressive disclosure** - Simple → Complex
+- **Include working examples** - Test every code snippet
+- **Show, don't just tell** - Practical examples over theory
+- **Use clear headings** - Easy to scan and find information
+- **Add troubleshooting** - Common issues and solutions
+- **Cross-reference** - Link to related docs
+- **Keep it up-to-date** - Documentation debt is real debt
+
+### Documentation Testing
+
+Before submitting changes:
+
+1. **Test all code examples** - They must actually work
+2. **Check all links** - No broken references
+3. **Review formatting** - Proper Markdown rendering
+4. **Verify completeness** - No missing steps or TODOs
+5. **Read as a beginner** - Is it clear without context?
+
 ## Common Pitfalls
 
 - File watcher disabled in GraalVM native image (check `running-on-native-image?`)
@@ -134,6 +226,7 @@ Tests are in `test/com/moclojer/`. Resource files for tests are in `test/com/moc
 |------|---------|----------------|
 | `specs/moclojer.clj` | Core spec parser, route generation | Adding new YAML/EDN features |
 | `specs/openapi.clj` | OpenAPI converter | OpenAPI compatibility |
+| `specs/postman.clj` | Postman Collection converter | Postman compatibility |
 | `router.clj` | Smart router, format detection | Changing routing logic |
 | `server.clj` | HTTP server, middleware chain | Adding middleware |
 | `adapters.clj` | Public API for library usage | Library interface changes |
@@ -143,13 +236,13 @@ Tests are in `test/com/moclojer/`. Resource files for tests are in `test/com/moc
 ## Data Flow
 
 ```
-YAML/EDN/OpenAPI file
+YAML/EDN/OpenAPI/Postman file
         ↓
 io-utils/open-file (parse to Clojure data)
         ↓
-router/smart-router (detect spec format)
+router/smart-router (detect spec format: :moclojer, :openapi, :postman)
         ↓
-specs/moclojer/->reitit or specs/openapi/->moclojer
+specs/moclojer/->reitit or specs/openapi/->moclojer or specs/postman/->moclojer
         ↓
 Reitit route definitions with handlers
         ↓
@@ -167,30 +260,48 @@ Request → Middleware → Handler → selmer/render → Response
 2. Add new key to the parameters map
 3. Variable becomes available as `{{new-key.field}}` in templates
 4. Add test in `test/com/moclojer/specs/moclojer_test.clj`
+5. **📚 Update `docs/topics/templates/template-variables.md` with new variable**
 
 ### Adding a new external-body provider (e.g., CSV)
 1. Create `src/com/moclojer/external_body/csv.clj`
 2. Implement function that returns parsed content as Clojure data
 3. Add case in `external_body/core.clj` → `type-identification`
 4. Add test with sample file in `test/com/moclojer/resources/`
+5. **📚 Update `docs/advanced/external-bodies.md` with CSV example**
 
 ### Adding a new middleware
 1. Create `src/com/moclojer/middleware/new_middleware.clj`
 2. Implement `wrap-*` function following Ring middleware pattern
 3. Add to middleware vector in `server.clj` → `reitit-router`
 4. Add test in `test/com/moclojer/middleware/`
+5. **📚 If user-facing: create `docs/advanced/new-middleware.md` guide**
 
 ### Adding a new spec format
 1. Create `src/com/moclojer/specs/newformat.clj`
 2. Implement `->moclojer` or `->reitit` conversion function
 3. Update `router.clj` → `smart-router` to detect new format
 4. Add test in `test/com/moclojer/specs/`
+5. **📚 DOCUMENTATION (REQUIRED):**
+   - Create `docs/getting-started/newformat.md` tutorial
+   - Update `docs/SUMMARY.md` with new page
+   - Update `docs/README.md` and `docs/getting-started/overview.md`
+   - Update main `README.md` to mention new format
+   - Add example file to `examples/` directory
+   - Update `CLAUDE.md` (this file)
+
+**Example: Postman Collection support (see `specs/postman.clj`)**
+- Detection: `smart-router` checks for `:info` and `:item` keys (Postman Collection v2.1 structure)
+- Conversion: `->moclojer` processes nested folders recursively, extracts response examples from `:response` array
+- Path handling: Converts both string URLs and object URLs to moclojer path format
+- Headers: Filters disabled headers, preserves enabled ones
+- Status codes: Uses `:code` from response examples, defaults to 200
+- Test file: `specs/postman_test.clj` includes nested folder tests, URL format variations, disabled headers
 
 ## Glossary
 
 | Term | Meaning |
 |------|---------|
-| spec | Mock endpoint definition in YAML/EDN/OpenAPI format |
+| spec | Mock endpoint definition in YAML/EDN/OpenAPI/Postman format |
 | endpoint | Single HTTP route with method, path, and response |
 | external-body | Response body loaded from external file (JSON, XLSX) |
 | path-params | URL parameters extracted from path (`:id` in `/users/:id`) |
@@ -199,6 +310,7 @@ Request → Middleware → Handler → selmer/render → Response
 | webhook | Async HTTP call triggered after sending response |
 | router | Reitit data structure defining all routes |
 | handler | Function that processes request and returns response |
+| postman collection | JSON export from Postman with API requests and response examples |
 
 ## Anti-patterns
 
@@ -211,6 +323,7 @@ Request → Middleware → Handler → selmer/render → Response
 - Throwing exceptions silently → log with context, return error response
 - Direct `slurp` for config → use `io-utils/open-file` (handles YAML/EDN/JSON)
 - Mutable state outside atoms → router state must be in atom for hot-reload
+- **📚 Code without documentation → ALWAYS update `docs/` when adding features**
 
 ## Tests as Documentation
 
@@ -221,5 +334,6 @@ Request → Middleware → Handler → selmer/render → Response
 | `webhook_test.clj` | Async webhook behavior |
 | `specs/moclojer_test.clj` | Spec parsing, template variables |
 | `specs/openapi_test.clj` | OpenAPI conversion |
+| `specs/postman_test.clj` | Postman Collection conversion, nested folders, path variables |
 | `external_body/*_test.clj` | External file loading |
 | `middleware/*_test.clj` | Middleware behavior |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
   <a href="https://www.producthunt.com/posts/moclojer?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-moclojer" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=449961&theme=neutral" alt="moclojer - &#0032;Simple&#0032;and&#0032;efficient&#0032;HTTP&#0032;mock&#0032;server&#0032;with&#0032;easy&#0032;spec | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 </p>
 
-Simple and efficient HTTP mock server with specification written in `yaml`, `edn` or `OpenAPI`.
+Simple and efficient HTTP mock server with specification written in `yaml`, `edn`, `OpenAPI` or `Postman Collection`.
 
 > 💾 Download the `.jar` file with the latest version of moclojer to test on your computer [here](https://github.com/moclojer/moclojer/releases/latest).
 
@@ -56,6 +56,33 @@ Simple and efficient HTTP mock server with specification written in `yaml`, `edn
           "hello": "{{path-params.username}}!"
         }
 ```
+
+**Postman Collection Support**
+
+Moclojer can directly use Postman Collection v2.1 exports as mock specifications. Simply export your Postman collection and use it:
+
+```sh
+# Using environment variable
+CONFIG=my-collection.json moclojer
+
+# Using CLI parameter
+moclojer --config my-collection.json
+```
+
+**How to export from Postman:**
+
+1. Open your Postman collection
+2. Click the three dots menu → Export
+3. Select "Collection v2.1" format
+4. Save the JSON file
+5. Use it directly with moclojer!
+
+The converter automatically:
+- Detects Postman Collection format
+- Extracts HTTP methods, paths, and response examples
+- Processes nested folders
+- Converts path variables (`:id`, `:username`, etc.)
+- Includes headers and status codes from examples
 
 **WebSocket Support**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,11 @@ New to moclojer? Start with our progressive tutorial series:
 
 1. **[Overview](getting-started/overview.md)** - Learn what moclojer is and why you'd want to use it
 2. **[Installation](getting-started/installation.md)** - Get moclojer running on your system
-3. **[Your First Mock Server](getting-started/your-first-mock.md)** - Create a working API in 10 minutes
-4. **[Dynamic Responses](getting-started/dynamic-responses.md)** - Make your mocks respond to request data
-5. **[Multiple Endpoints](getting-started/multiple-endpoints.md)** - Build complete APIs with proper structure
-6. **[Real-World Example](getting-started/real-world-example.md)** - Complete e-commerce API tutorial
+3. **[Using Postman Collections](getting-started/postman-collections.md)** - Use your existing Postman Collections directly
+4. **[Your First Mock Server](getting-started/your-first-mock.md)** - Create a working API in 10 minutes
+5. **[Dynamic Responses](getting-started/dynamic-responses.md)** - Make your mocks respond to request data
+6. **[Multiple Endpoints](getting-started/multiple-endpoints.md)** - Build complete APIs with proper structure
+7. **[Real-World Example](getting-started/real-world-example.md)** - Complete e-commerce API tutorial
 
 ## 📚 Documentation Structure
 
@@ -22,7 +23,7 @@ Perfect for beginners - get up and running quickly with guided tutorials.
 
 ### 🧠 Core Concepts
 Understand how moclojer works with detailed explanations of key concepts:
-- **Configuration** - YAML, EDN, and OpenAPI formats
+- **Configuration** - YAML, EDN, OpenAPI, and Postman Collection formats
 - **Endpoints** - HTTP methods, paths, and responses
 - **Templates** - Dynamic content generation
 - **Parameters** - Path, query, body, and header handling

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,6 +6,7 @@ Are you new to moclojer? This is the place to start!
 
 * [Overview](getting-started/overview.md)
 * [Installation](getting-started/installation.md)
+* [Using Postman Collections](getting-started/postman-collections.md)
 * [Your First Mock Server](getting-started/your-first-mock.md)
 * [Dynamic Responses](getting-started/dynamic-responses.md)
 * [Multiple Endpoints](getting-started/multiple-endpoints.md)

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -24,7 +24,7 @@ Support for dynamic responses, path parameters, query parameters, WebSockets, we
 
 ## How does it work?
 
-moclojer reads configuration files (YAML, EDN, or OpenAPI) that describe your API endpoints and their responses. When a request comes in, it matches the request to your configuration and returns the appropriate response.
+moclojer reads configuration files (YAML, EDN, OpenAPI, or Postman Collections) that describe your API endpoints and their responses. When a request comes in, it matches the request to your configuration and returns the appropriate response.
 
 **Simple example:**
 
@@ -146,10 +146,11 @@ Mock external APIs for development and testing:
 Ready to create your first mock API? Here's what you'll learn:
 
 1. **[Installation](installation.md)** - Get moclojer running on your system
-2. **[Your First Mock Server](your-first-mock.md)** - Create and test a simple API
-3. **[Dynamic Responses](dynamic-responses.md)** - Make your mocks respond to different inputs
-4. **[Multiple Endpoints](multiple-endpoints.md)** - Build a complete API with multiple routes
-5. **[Real-World Example](real-world-example.md)** - Put it all together with a practical example
+2. **[Using Postman Collections](postman-collections.md)** - Already have Postman Collections? Start here!
+3. **[Your First Mock Server](your-first-mock.md)** - Create and test a simple API with YAML
+4. **[Dynamic Responses](dynamic-responses.md)** - Make your mocks respond to different inputs
+5. **[Multiple Endpoints](multiple-endpoints.md)** - Build a complete API with multiple routes
+6. **[Real-World Example](real-world-example.md)** - Put it all together with a practical example
 
 Each tutorial builds on the previous one, so you'll have a solid understanding of moclojer by the end.
 

--- a/docs/getting-started/postman-collections.md
+++ b/docs/getting-started/postman-collections.md
@@ -1,0 +1,275 @@
+---
+description: >-
+  Use your existing Postman Collections directly with moclojer. No conversion needed - just export and run!
+---
+
+# Using Postman Collections
+
+If you already have API specifications in Postman, you can use them directly with moclojer without any conversion. This is perfect when you have existing Postman Collections and want to quickly spin up a mock server.
+
+## What is Postman Collection Support?
+
+Moclojer can read **Postman Collection v2.1** JSON files and automatically convert them into working mock endpoints. This means you can:
+
+- ✅ Export collections from Postman
+- ✅ Use them directly with moclojer
+- ✅ No manual conversion or rewriting needed
+- ✅ All your response examples become live endpoints
+
+## Quick Start
+
+### Step 1: Export from Postman
+
+1. Open Postman and find your collection
+2. Click the **three dots (...)** next to the collection name
+3. Select **Export**
+4. Choose **Collection v2.1** format
+5. Save the JSON file (e.g., `my-api.json`)
+
+### Step 2: Run with moclojer
+
+```bash
+# Using environment variable
+CONFIG=my-api.json moclojer
+
+# Or using CLI parameter
+moclojer --config my-api.json
+
+# With custom port
+CONFIG=my-api.json PORT=3000 moclojer
+```
+
+That's it! Your Postman Collection is now a live mock server! 🎉
+
+## How It Works
+
+Moclojer reads your Postman Collection and:
+
+1. **Detects the format automatically** - No need to specify it's a Postman Collection
+2. **Extracts all requests** - Both top-level and nested in folders
+3. **Uses response examples** - The first saved example becomes the mock response
+4. **Converts path variables** - `:id`, `:username`, etc. work automatically
+5. **Includes headers** - Response headers from your examples are preserved
+6. **Respects status codes** - Each example's status code is used
+
+## Example
+
+Let's say you have this Postman Collection:
+
+```json
+{
+  "info": {
+    "name": "Users API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Get User",
+      "request": {
+        "method": "GET",
+        "url": "http://localhost:8000/users/:id"
+      },
+      "response": [
+        {
+          "name": "Success",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "body": "{\"id\": 1, \"name\": \"Alice\", \"email\": \"alice@example.com\"}"
+        }
+      ]
+    }
+  ]
+}
+```
+
+After running `CONFIG=users-api.json moclojer`, you can:
+
+```bash
+curl http://localhost:8000/users/123
+# Returns: {"id": 1, "name": "Alice", "email": "alice@example.com"}
+```
+
+## Response Examples in Postman
+
+For moclojer to work properly, your Postman requests need **saved response examples**. Here's how to add them:
+
+### Adding a Response Example
+
+1. **Make a request** in Postman (or use an existing one)
+2. Click the **"Save Response"** button → **"Save as Example"**
+3. **Edit the example**:
+   - Set the status code (200, 404, etc.)
+   - Add headers if needed
+   - Write the response body (JSON, XML, text, etc.)
+4. **Save the example**
+
+### Multiple Examples
+
+If a request has multiple examples, moclojer uses the **first one**. To choose which example to use:
+
+- Reorder examples in Postman (drag and drop)
+- Or keep only the example you want
+
+## Nested Folders
+
+Postman Collections can organize requests into folders. Moclojer handles this automatically:
+
+```
+Users API
+├── Users
+│   ├── List Users (GET /users)
+│   ├── Get User (GET /users/:id)
+│   └── Create User (POST /users)
+└── Health
+    └── Health Check (GET /health)
+```
+
+All requests become endpoints, regardless of folder nesting. The folder structure is just for organization.
+
+## Path Variables
+
+Postman and moclojer both use the same syntax for path variables:
+
+| Postman URL | Moclojer Path | Works? |
+|-------------|---------------|---------|
+| `http://localhost:8000/users/:id` | `/users/:id` | ✅ Yes |
+| `http://localhost:8000/posts/:postId/comments/:commentId` | `/posts/:postId/comments/:commentId` | ✅ Yes |
+| `{{baseUrl}}/users/:id` | `/users/:id` | ✅ Yes (variables ignored) |
+
+## What's Supported
+
+| Feature | Supported | Notes |
+|---------|-----------|-------|
+| HTTP Methods | ✅ GET, POST, PUT, DELETE, PATCH, etc. | All standard methods |
+| Path parameters | ✅ `:id`, `:name`, etc. | Automatic conversion |
+| Response status codes | ✅ 200, 404, 500, etc. | From examples |
+| Response headers | ✅ All headers | From examples |
+| Response body | ✅ JSON, text, etc. | From examples |
+| Nested folders | ✅ Unlimited depth | Flattened to endpoints |
+| Multiple requests | ✅ Unlimited | All become endpoints |
+| Request body | ⚠️ Ignored | Only responses are mocked |
+| Request headers | ⚠️ Ignored | Only responses are mocked |
+| Pre-request scripts | ❌ Not supported | Postman-specific |
+| Tests | ❌ Not supported | Postman-specific |
+| Variables | ❌ Not supported | Use environment vars instead |
+
+## Complete Example
+
+Let's create a complete Postman Collection for a pet store:
+
+### 1. Create in Postman
+
+Create a collection with these requests:
+
+**GET /pets** - List all pets
+- Response example: `200 OK`
+- Body: `[{"id": 1, "name": "Caramelo", "type": "dog"}]`
+
+**GET /pets/:id** - Get one pet
+- Response example: `200 OK`
+- Body: `{"id": 1, "name": "Caramelo", "type": "dog"}`
+
+**POST /pets** - Create a pet
+- Response example: `201 Created`
+- Body: `{"id": 2, "name": "New Pet", "type": "cat"}`
+
+**DELETE /pets/:id** - Delete a pet
+- Response example: `204 No Content`
+- Body: (empty)
+
+### 2. Export
+
+Export as "Collection v2.1" → `petstore.json`
+
+### 3. Run
+
+```bash
+CONFIG=petstore.json moclojer
+```
+
+### 4. Test
+
+```bash
+# List pets
+curl http://localhost:8000/pets
+
+# Get specific pet
+curl http://localhost:8000/pets/123
+
+# Create pet
+curl -X POST http://localhost:8000/pets \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Rex","type":"dog"}'
+
+# Delete pet
+curl -X DELETE http://localhost:8000/pets/123
+```
+
+## Tips and Best Practices
+
+### ✅ Do:
+
+- **Save response examples** for every request you want to mock
+- **Use realistic data** in your examples
+- **Set correct status codes** (200, 201, 404, etc.)
+- **Include headers** when they matter (Content-Type, etc.)
+- **Organize with folders** for clarity
+- **Use descriptive names** for requests and examples
+
+### ❌ Don't:
+
+- **Forget response examples** - Without them, you get default `200 {}` response
+- **Use Postman variables in URLs** - They won't be resolved (use full paths)
+- **Rely on pre-request scripts** - They won't run in moclojer
+- **Expect request validation** - moclojer doesn't validate request bodies
+
+## Comparison with Other Formats
+
+| Feature | Postman Collection | YAML/EDN | OpenAPI |
+|---------|-------------------|----------|---------|
+| **Ease of setup** | ⭐⭐⭐⭐⭐ Click and export | ⭐⭐⭐ Write by hand | ⭐⭐⭐⭐ Generate from code |
+| **Visual editing** | ⭐⭐⭐⭐⭐ Postman UI | ⭐ Text editor | ⭐⭐ Various tools |
+| **Dynamic responses** | ❌ Static examples | ✅ Full templating | ⚠️ Requires mocks file |
+| **Team collaboration** | ⭐⭐⭐⭐⭐ Built for teams | ⭐⭐⭐ Version control | ⭐⭐⭐⭐ Standard format |
+| **Best for** | Quick mocks from existing collections | Custom logic and templates | API-first design |
+
+## Next Steps
+
+Now that you know how to use Postman Collections with moclojer:
+
+- **Need dynamic responses?** See [Dynamic Responses](dynamic-responses.md) to learn about templates
+- **Want to write YAML instead?** See [Your First Mock Server](your-first-mock.md)
+- **Looking for advanced features?** Check [Advanced Features](../advanced/) section
+
+## Troubleshooting
+
+### "No endpoints found"
+
+**Problem**: moclojer starts but no endpoints work
+
+**Solution**: Make sure your Postman requests have saved response examples
+
+---
+
+### "Getting 200 with empty {}"
+
+**Problem**: Endpoints return `{"status": 200, "body": "{}"}`
+
+**Solution**: Add response examples to your Postman requests
+
+---
+
+### "Path variables not working"
+
+**Problem**: `/users/:id` always returns the same data
+
+**Solution**: This is expected with Postman Collections. They use static examples. For dynamic responses based on path variables, use [YAML format with templates](dynamic-responses.md)
+
+---
+
+**Ready to create your first mock?** Export a Postman Collection and give it a try! 🚀

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,85 @@
+# Moclojer Examples
+
+This directory contains example configurations for moclojer in different formats.
+
+## Postman Collection Example
+
+The `petstore-postman-collection.json` file is a complete Postman Collection v2.1 example that can be used directly with moclojer.
+
+### How to use:
+
+**1. Run with moclojer:**
+
+```bash
+# Using environment variable
+CONFIG=examples/petstore-postman-collection.json moclojer
+
+# Using CLI parameter
+moclojer --config examples/petstore-postman-collection.json
+
+# With custom port
+CONFIG=examples/petstore-postman-collection.json PORT=3000 moclojer
+```
+
+**2. Test the endpoints:**
+
+```bash
+# List all pets
+curl http://localhost:8000/pets
+
+# Get specific pet
+curl http://localhost:8000/pets/1
+
+# Create new pet
+curl -X POST http://localhost:8000/pets \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Rex","type":"dog","age":2}'
+
+# Update pet
+curl -X PUT http://localhost:8000/pets/1 \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Updated Pet","age":4}'
+
+# Delete pet
+curl -X DELETE http://localhost:8000/pets/1
+
+# Health check
+curl http://localhost:8000/health
+```
+
+### Features demonstrated:
+
+- ✅ HTTP methods: GET, POST, PUT, DELETE
+- ✅ Path parameters (`:id`)
+- ✅ Response examples with status codes
+- ✅ Custom headers
+- ✅ Nested folders for organization
+- ✅ Different response formats
+
+### Creating your own Postman Collection for moclojer:
+
+1. **In Postman**, create or use an existing collection
+2. Add **response examples** to your requests:
+   - Click on a request
+   - Click "Save Response" → "Save as Example"
+   - Add status code, headers, and body
+3. **Export the collection**:
+   - Right-click on collection → Export
+   - Select "Collection v2.1"
+   - Save the JSON file
+4. **Use with moclojer**:
+   - `CONFIG=your-collection.json moclojer`
+
+### Tips:
+
+- Moclojer uses the **first response example** from each request
+- Path variables (`:id`, `:username`, etc.) are automatically detected
+- Nested folders are flattened - all requests become endpoints
+- Disabled headers in Postman are ignored by moclojer
+- If no response example exists, moclojer returns `200 OK` with empty JSON `{}`
+
+## Server Examples
+
+The `server/` directory contains examples of using moclojer as a library in Clojure applications.
+
+See [server/README.md](server/README.md) for more details.

--- a/examples/petstore-postman-collection.json
+++ b/examples/petstore-postman-collection.json
@@ -1,0 +1,183 @@
+{
+  "info": {
+    "name": "Petstore API - Moclojer Example",
+    "description": "Example Postman Collection for Moclojer. Export this from Postman and use directly with moclojer:\n\nCONFIG=petstore-postman-collection.json moclojer\n\nThis collection demonstrates:\n- GET, POST, PUT, DELETE methods\n- Path parameters (:id)\n- Response examples with different status codes\n- Headers configuration\n- Nested folders for organization",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "moclojer"
+  },
+  "item": [
+    {
+      "name": "Pets",
+      "description": "Pet management endpoints",
+      "item": [
+        {
+          "name": "List all pets",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/pets",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["pets"]
+            },
+            "description": "Returns a list of all pets in the store"
+          },
+          "response": [
+            {
+              "name": "Success Response",
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "[\n  {\n    \"id\": 1,\n    \"name\": \"Caramelo\",\n    \"type\": \"dog\",\n    \"age\": 3\n  },\n  {\n    \"id\": 2,\n    \"name\": \"Mingau\",\n    \"type\": \"cat\",\n    \"age\": 2\n  }\n]"
+            }
+          ]
+        },
+        {
+          "name": "Get pet by ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "http://localhost:8000/pets/:id",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "8000",
+              "path": ["pets", ":id"]
+            },
+            "description": "Returns a single pet by ID"
+          },
+          "response": [
+            {
+              "name": "Pet found",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"id\": 1,\n  \"name\": \"Caramelo\",\n  \"type\": \"dog\",\n  \"age\": 3\n}"
+            }
+          ]
+        },
+        {
+          "name": "Create a pet",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "http://localhost:8000/pets",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"New Pet\",\n  \"type\": \"dog\",\n  \"age\": 1\n}"
+            },
+            "description": "Creates a new pet"
+          },
+          "response": [
+            {
+              "name": "Pet created",
+              "code": 201,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                },
+                {
+                  "key": "Location",
+                  "value": "/pets/3"
+                }
+              ],
+              "body": "{\n  \"id\": 3,\n  \"name\": \"New Pet\",\n  \"type\": \"dog\",\n  \"age\": 1\n}"
+            }
+          ]
+        },
+        {
+          "name": "Update pet",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:8000/pets/:id",
+              "path": ["pets", ":id"]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Updated Pet\",\n  \"age\": 4\n}"
+            },
+            "description": "Updates an existing pet"
+          },
+          "response": [
+            {
+              "name": "Pet updated",
+              "code": 200,
+              "body": "{\n  \"id\": 1,\n  \"name\": \"Updated Pet\",\n  \"type\": \"dog\",\n  \"age\": 4\n}"
+            }
+          ]
+        },
+        {
+          "name": "Delete pet",
+          "request": {
+            "method": "DELETE",
+            "url": "http://localhost:8000/pets/:id",
+            "description": "Deletes a pet by ID"
+          },
+          "response": [
+            {
+              "name": "Pet deleted",
+              "code": 204,
+              "body": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Health",
+      "description": "Health check endpoints",
+      "item": [
+        {
+          "name": "Health check",
+          "request": {
+            "method": "GET",
+            "url": "http://localhost:8000/health"
+          },
+          "response": [
+            {
+              "name": "Healthy",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                }
+              ],
+              "body": "{\n  \"status\": \"healthy\",\n  \"uptime\": 12345,\n  \"timestamp\": \"2025-12-21T20:00:00Z\"\n}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/com/moclojer/io_utils.clj
+++ b/src/com/moclojer/io_utils.clj
@@ -1,5 +1,6 @@
 (ns com.moclojer.io-utils
-  (:require [clojure.edn :as edn]
+  (:require [cheshire.core :as json]
+            [clojure.edn :as edn]
             [clojure.string :as string]
             [com.moclojer.log :as log]
             [yaml.core :as yaml])
@@ -9,8 +10,14 @@
   (if (empty? path)
     (log/log :error :open-config :not-found "file not found" :path path)
     (try
-      (if (string/ends-with? path ".edn")
+      (cond
+        (string/ends-with? path ".edn")
         (edn/read-string (str "[" (slurp path) "]"))
+
+        (string/ends-with? path ".json")
+        (json/parse-string (slurp path) true)
+
+        :else
         (yaml/from-file path))
       (catch FileNotFoundException e
         (log/log :error :open-config :exception (str "file not found" e))))))

--- a/src/com/moclojer/router.clj
+++ b/src/com/moclojer/router.clj
@@ -3,7 +3,8 @@
    [clojure.data.json :as json]
    [com.moclojer.log :as log]
    [com.moclojer.specs.moclojer :as spec]
-   [com.moclojer.specs.openapi :as openapi]))
+   [com.moclojer.specs.openapi :as openapi]
+   [com.moclojer.specs.postman :as postman]))
 
 (def ^:private home-endpoint
   "Prebuilt endpoint for `/`."
@@ -14,18 +15,46 @@
                          :body (json/write-str '(-> moclojer server))
                          :status 200}}})
 
+(defn- detect-spec-type
+  "Detects the type of spec based on the structure.
+
+  Returns one of: :postman, :openapi, :moclojer"
+  [config]
+  (cond
+    ;; Postman Collection has :info and :item keys
+    (and (:info config) (:item config))
+    :postman
+
+    ;; OpenAPI has :paths key
+    (:paths config)
+    :openapi
+
+    ;; Default to moclojer native format
+    :else
+    :moclojer))
+
 (defn smart-router
   "Given a list of mock endpoints that comply to either our
-  in-house moclojer spec or openapi's spec, builds a generic
-  reitit route that can be used later by the webserver.
+  in-house moclojer spec, openapi's spec, or postman collection,
+  builds a generic reitit route that can be used later by the webserver.
 
   See also: `com.moclojer.adapters`."
   [{:keys [::config ::mocks]}]
-  (let [mode (if mocks :openapi :moclojer)
-        routes (if (seq mocks)
+  (let [spec-type (detect-spec-type config)
+        mode (if mocks :openapi spec-type)
+        routes (cond
+                 ;; OpenAPI with mocks file
+                 (and (= spec-type :openapi) (seq mocks))
                  (if (vector? mocks)
                    mocks
                    (openapi/->moclojer config mocks))
+
+                 ;; Postman Collection
+                 (= spec-type :postman)
+                 (postman/->moclojer config)
+
+                 ;; Moclojer native format
+                 :else
                  config)]
 
     (log/log :info :spec-mode :mode mode)

--- a/src/com/moclojer/specs/postman.clj
+++ b/src/com/moclojer/specs/postman.clj
@@ -1,0 +1,114 @@
+(ns com.moclojer.specs.postman
+  (:require
+   [clojure.string :as str]))
+
+(defn- parse-url
+  "Parses Postman URL object or string to extract path.
+
+  Postman URL can be:
+  - String: 'http://localhost:3000/pets/:id'
+  - Object: {:raw '...' :path ['pets' ':id']}
+
+  Returns path in moclojer format: /pets/:id"
+  [url]
+  (cond
+    (string? url)
+    (-> url
+        (str/replace #"^https?://[^/]+" "")
+        (str/replace #"\?.*$" "")
+        (#(if (str/starts-with? % "/") % (str "/" %))))
+
+    (map? url)
+    (let [path-segments (or (:path url) [])]
+      (str "/" (str/join "/" path-segments)))
+
+    :else "/"))
+
+(defn- extract-headers
+  "Extracts headers from Postman request.
+
+  Postman headers format: [{:key 'Content-Type' :value 'application/json'}]
+  Returns: {'Content-Type' 'application/json'}"
+  [headers]
+  (when (seq headers)
+    (reduce (fn [acc {:keys [key value disabled]}]
+              (if disabled
+                acc
+                (assoc acc key value)))
+            {}
+            headers)))
+
+(defn- extract-response-body
+  "Extracts body from Postman response example.
+
+  Returns the body as string or nil if not present."
+  [response-example]
+  (when-let [body (:body response-example)]
+    (if (string? body)
+      body
+      (pr-str body))))
+
+(defn- pick-response-example
+  "Picks the first response example from Postman request.
+
+  Returns map with :status, :body, :headers or default 200 response."
+  [response-examples]
+  (if-let [example (first response-examples)]
+    (let [body (extract-response-body example)
+          headers (extract-headers (:header example))]
+      (cond-> {:status (or (:code example) 200)}
+        body (assoc :body body)
+        headers (assoc :headers headers)))
+    {:status 200
+     :body "{}"
+     :headers {"Content-Type" "application/json"}}))
+
+(defn- process-request
+  "Converts a Postman request item to moclojer endpoint format.
+
+  Input: Postman item with :request key
+  Output: {:endpoint {:method ... :path ... :response ...}}"
+  [{:keys [request response]}]
+  (when request
+    (let [method (str/upper-case (or (:method request) "GET"))
+          path (parse-url (:url request))
+          response-data (pick-response-example response)]
+      {:endpoint {:method method
+                  :path path
+                  :response response-data}})))
+
+(defn- process-item
+  "Recursively processes Postman collection items.
+
+  Items can be:
+  - Request: has :request key
+  - Folder: has :item key (array of items)
+
+  Returns flat list of endpoints."
+  [item]
+  (cond
+    ;; Folder with nested items
+    (:item item)
+    (mapcat process-item (:item item))
+
+    ;; Request item
+    (:request item)
+    [(process-request item)]
+
+    ;; Unknown/empty item
+    :else
+    []))
+
+(defn ->moclojer
+  "Converts Postman Collection v2.1 to moclojer spec.
+
+  Input: Postman collection map with :info and :item keys
+  Output: Vector of {:endpoint {...}} maps
+
+  Example:
+    Input: {:info {...} :item [{:request {:method 'GET' :url {...}}}]}
+    Output: [{:endpoint {:method 'GET' :path '/pets' :response {...}}}]"
+  [collection]
+  (->> (:item collection)
+       (mapcat process-item)
+       (filterv some?)))

--- a/test/com/moclojer/resources/postman-collection-example.json
+++ b/test/com/moclojer/resources/postman-collection-example.json
@@ -1,0 +1,104 @@
+{
+  "info": {
+    "name": "Pets API",
+    "description": "Sample Postman Collection for testing",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Get all pets",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:3000/pets",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["pets"]
+        }
+      },
+      "response": [
+        {
+          "name": "Success",
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "body": "[{\"id\":1,\"name\":\"caramelo\"},{\"id\":2,\"name\":\"bob\"}]"
+        }
+      ]
+    },
+    {
+      "name": "Get pet by ID",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/pets/:id",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["pets", ":id"]
+        }
+      },
+      "response": [
+        {
+          "name": "Pet found",
+          "code": 200,
+          "body": "{\"id\":1,\"name\":\"caramelo\"}"
+        }
+      ]
+    },
+    {
+      "name": "Pet Operations",
+      "item": [
+        {
+          "name": "Create pet",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "http://localhost:3000/pets",
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":\"new pet\"}"
+            }
+          },
+          "response": [
+            {
+              "code": 201,
+              "body": "{\"id\":3,\"name\":\"new pet\"}"
+            }
+          ]
+        },
+        {
+          "name": "Delete pet",
+          "request": {
+            "method": "DELETE",
+            "url": "http://localhost:3000/pets/:id"
+          },
+          "response": [
+            {
+              "code": 204,
+              "body": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/com/moclojer/router_test.clj
+++ b/test/com/moclojer/router_test.clj
@@ -1,5 +1,6 @@
 (ns com.moclojer.router-test
   (:require
+   [cheshire.core :as json]
    [clojure.test :refer [deftest is testing]]
    [com.moclojer.router :as router]
    [yaml.core :as yaml]))
@@ -28,6 +29,15 @@
                              :body    {:id 1 :name "chico"}}
                :router-name :get-pet-by-id}}])
 
+(def postman-sample
+  {:info {:name "Test Collection"
+          :schema "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"}
+   :item [{:name "Get Users"
+           :request {:method "GET"
+                     :url {:path ["users"]}}
+           :response [{:code 200
+                       :body "[{\"id\":1}]"}]}]})
+
 (deftest smart-router-test
   (testing "should make edn routers"
     (let [routers (router/smart-router
@@ -40,4 +50,22 @@
     (testing "should make yaml routers"
       (let [yaml-routers (router/smart-router
                           {::router/config yaml-sample})]
-        (is (= (count yaml-routers) 3))))))
+        (is (= (count yaml-routers) 3)))))
+
+  (testing "should make postman routers"
+    (let [routers (router/smart-router
+                   {::router/config postman-sample})]
+      (is (= (count routers) 3))
+      (is (= (ffirst routers) ""))
+      (is (= (first (get routers 1)) "/users"))
+      (is (= (first (get routers 2)) "/swagger.json"))))
+
+  (testing "should detect postman collection from file"
+    (let [collection (json/parse-string
+                      (slurp "test/com/moclojer/resources/postman-collection-example.json")
+                      true)
+          routers (router/smart-router
+                   {::router/config collection})]
+      ;; Should have: home endpoint + /pets (GET+POST merged) + /pets/:id (GET+DELETE merged) + swagger
+      (is (= (count routers) 4))
+      (is (= (ffirst routers) "")))))

--- a/test/com/moclojer/specs/postman_test.clj
+++ b/test/com/moclojer/specs/postman_test.clj
@@ -1,0 +1,154 @@
+(ns com.moclojer.specs.postman-test
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer [deftest is testing]]
+   [com.moclojer.specs.postman :as postman]))
+
+(def sample-collection
+  "Sample Postman Collection for testing"
+  {:info {:name "Test API"
+          :schema "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"}
+   :item [{:name "Get Users"
+           :request {:method "GET"
+                     :url {:raw "http://localhost:3000/users"
+                           :path ["users"]}
+                     :header [{:key "Content-Type"
+                               :value "application/json"}]}
+           :response [{:code 200
+                       :body "[{\"id\":1,\"name\":\"Alice\"}]"
+                       :header [{:key "Content-Type"
+                                 :value "application/json"}]}]}
+          {:name "Get User by ID"
+           :request {:method "GET"
+                     :url {:path ["users" ":id"]}}
+           :response [{:code 200
+                       :body "{\"id\":1,\"name\":\"Alice\"}"}]}
+          {:name "Folder"
+           :item [{:name "Create User"
+                   :request {:method "POST"
+                             :url "http://localhost:3000/users"}
+                   :response [{:code 201
+                               :body "{\"id\":2,\"name\":\"Bob\"}"}]}
+                  {:name "Delete User"
+                   :request {:method "DELETE"
+                             :url {:path ["users" ":id"]}}
+                   :response [{:code 204}]}]}]})
+
+(deftest postman->moclojer-basic
+  (testing "Should convert Postman collection to moclojer spec"
+    (let [endpoints (postman/->moclojer sample-collection)]
+      (is (= 4 (count endpoints)))
+
+      ;; First endpoint: GET /users
+      (is (= {:endpoint {:method "GET"
+                         :path "/users"
+                         :response {:status 200
+                                    :body "[{\"id\":1,\"name\":\"Alice\"}]"
+                                    :headers {"Content-Type" "application/json"}}}}
+             (first endpoints)))
+
+      ;; Second endpoint: GET /users/:id
+      (is (= {:endpoint {:method "GET"
+                         :path "/users/:id"
+                         :response {:status 200
+                                    :body "{\"id\":1,\"name\":\"Alice\"}"}}}
+             (second endpoints)))
+
+      ;; Third endpoint: POST /users (from folder)
+      (is (= {:endpoint {:method "POST"
+                         :path "/users"
+                         :response {:status 201
+                                    :body "{\"id\":2,\"name\":\"Bob\"}"}}}
+             (nth endpoints 2)))
+
+      ;; Fourth endpoint: DELETE /users/:id (from folder)
+      (is (= {:endpoint {:method "DELETE"
+                         :path "/users/:id"
+                         :response {:status 204}}}
+             (nth endpoints 3))))))
+
+(deftest postman->moclojer-url-formats
+  (testing "Should handle different URL formats"
+    (let [collection {:info {:name "URL Tests"}
+                      :item [{:request {:method "GET"
+                                        :url "http://localhost:3000/api/items"}}
+                             {:request {:method "GET"
+                                        :url {:path ["api" "items" ":id"]}}}
+                             {:request {:method "GET"
+                                        :url "http://example.com/api/search?q=test"}}]}
+          endpoints (postman/->moclojer collection)]
+
+      (is (= "/api/items" (get-in endpoints [0 :endpoint :path])))
+      (is (= "/api/items/:id" (get-in endpoints [1 :endpoint :path])))
+      ;; Query params should be stripped
+      (is (= "/api/search" (get-in endpoints [2 :endpoint :path]))))))
+
+(deftest postman->moclojer-disabled-headers
+  (testing "Should skip disabled headers in response"
+    (let [collection {:info {:name "Header Tests"}
+                      :item [{:request {:method "GET"
+                                        :url "/test"}
+                               :response [{:code 200
+                                           :header [{:key "Enabled-Header"
+                                                     :value "value1"}
+                                                    {:key "Disabled-Header"
+                                                     :value "value2"
+                                                     :disabled true}]}]}]}
+          endpoints (postman/->moclojer collection)
+          headers (get-in endpoints [0 :endpoint :response :headers])]
+
+      (is (= "value1" (get headers "Enabled-Header")))
+      (is (nil? (get headers "Disabled-Header"))))))
+
+(deftest postman->moclojer-no-response-example
+  (testing "Should provide default response when no examples"
+    (let [collection {:info {:name "No Response"}
+                      :item [{:request {:method "GET"
+                                        :url "/test"}}]}
+          endpoints (postman/->moclojer collection)
+          response (get-in endpoints [0 :endpoint :response])]
+
+      (is (= 200 (:status response)))
+      (is (= "{}" (:body response)))
+      (is (= {"Content-Type" "application/json"} (:headers response))))))
+
+(deftest postman->moclojer-nested-folders
+  (testing "Should flatten nested folders"
+    (let [collection {:info {:name "Nested"}
+                      :item [{:name "Level 1"
+                              :item [{:name "Level 2"
+                                      :item [{:request {:method "GET"
+                                                        :url "/deep"}}]}]}]}
+          endpoints (postman/->moclojer collection)]
+
+      (is (= 1 (count endpoints)))
+      (is (= "/deep" (get-in endpoints [0 :endpoint :path]))))))
+
+(deftest postman->moclojer-from-file
+  (testing "Should convert real Postman collection file"
+    (let [collection (json/parse-string
+                      (slurp "test/com/moclojer/resources/postman-collection-example.json")
+                      true)
+          endpoints (postman/->moclojer collection)]
+
+      (is (= 4 (count endpoints)))
+
+      ;; Verify GET /pets
+      (is (some #(and (= "GET" (get-in % [:endpoint :method]))
+                      (= "/pets" (get-in % [:endpoint :path])))
+                endpoints))
+
+      ;; Verify GET /pets/:id
+      (is (some #(and (= "GET" (get-in % [:endpoint :method]))
+                      (= "/pets/:id" (get-in % [:endpoint :path])))
+                endpoints))
+
+      ;; Verify POST /pets (from folder)
+      (is (some #(and (= "POST" (get-in % [:endpoint :method]))
+                      (= "/pets" (get-in % [:endpoint :path])))
+                endpoints))
+
+      ;; Verify DELETE /pets/:id (from folder)
+      (is (some #(and (= "DELETE" (get-in % [:endpoint :method]))
+                      (= "/pets/:id" (get-in % [:endpoint :path])))
+                endpoints)))))


### PR DESCRIPTION
Users had to manually convert Postman Collections to YAML or rely on OpenAPI, creating friction when they already had API specs in Postman.

Implemented automatic Postman Collection detection and conversion. The smart router now recognizes Collection v2.1 format (via :info and :item keys) and converts it to moclojer's internal format. Response examples from Postman become live mock endpoints, nested folders are flattened, path variables are converted automatically, and headers/status codes are preserved. Added comprehensive documentation including a tutorial page, examples directory with working collection, and updated all getting-started guides to mention Postman as a first-class format alongside YAML and OpenAPI.

fixed: #43