### PR TITLE
  Add global external-body folder configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ clj -X:deploy-clojars
 ### Key Components
 
 - **Template Engine**: Uses Selmer for dynamic responses. Variables: `{{path-params.name}}`, `{{query-params.name}}`, `{{json-params.field}}`
-- **External Body**: Supports JSON and XLSX files as response sources (`com.moclojer.external-body.*`)
+- **External Body**: Supports JSON and XLSX files as response sources (`com.moclojer.external-body.*`). Global folder configuration available via `- external-body: { folder: path }` in spec.
 - **Middleware**: Rate limiting (`middleware/rate_limit.clj`) and latency simulation (`middleware/latency.clj`)
 - **Webhooks**: Async webhook calls with configurable delay and conditions (`com.moclojer.webhook`)
 - **File Watcher**: Hot reload on config changes (disabled in GraalVM native image)
@@ -243,14 +243,16 @@ io-utils/open-file (parse to Clojure data)
 router/smart-router (detect spec format: :moclojer, :openapi, :postman)
         ↓
 specs/moclojer/->reitit or specs/openapi/->moclojer or specs/postman/->moclojer
+  ├─ Extract global config (e.g., external-body folder)
+  └─ Pass global config to route processors
         ↓
-Reitit route definitions with handlers
+Reitit route definitions with handlers (handlers close over global config)
         ↓
 server/reitit-router (wrap with middleware chain)
         ↓
 http-kit/run-server (start listening)
         ↓
-Request → Middleware → Handler → selmer/render → Response
+Request → Middleware → Handler → enrich-external-body (with global folder) → selmer/render → Response
 ```
 
 ## Common Tasks

--- a/docs/advanced/external-bodies.md
+++ b/docs/advanced/external-bodies.md
@@ -65,6 +65,108 @@ Replace `body` with `external-body`:
 | `path` | Yes | File path (local or HTTP URL) |
 | `sheet-name` | No | Excel sheet name (xlsx only) |
 
+## 🌍 Global Configuration
+
+To avoid repeating the folder path in every endpoint, you can configure a global base folder for external bodies:
+
+```yaml
+# Global configuration
+- external-body:
+    folder: data/responses
+
+# Endpoints can now use relative paths
+- endpoint:
+    method: GET
+    path: /api/users
+    response:
+      status: 200
+      external-body:
+        provider: json
+        path: users.json  # Will resolve to: data/responses/users.json
+
+- endpoint:
+    method: GET
+    path: /api/products
+    response:
+      status: 200
+      external-body:
+        provider: json
+        path: products.json  # Will resolve to: data/responses/products.json
+```
+
+### When to Use Global Configuration
+
+**Perfect for:**
+
+- ✅ Docker/Kubernetes deployments with mounted volumes
+- ✅ Consistent folder structure across all endpoints
+- ✅ Reducing configuration duplication
+- ✅ Cleaner, more maintainable configuration
+
+**Example: Docker Compose Setup**
+
+```yaml
+# docker-compose.yml
+services:
+  moclojer:
+    image: moclojer/moclojer:latest
+    volumes:
+      - ./config.yml:/config.yml
+      - ./mock-data:/app/bodies  # Mount data directory
+    command: --config /config.yml
+```
+
+```yaml
+# config.yml
+- external-body:
+    folder: /app/bodies  # All files loaded from here
+
+- endpoint:
+    method: GET
+    path: /api/users
+    response:
+      external-body:
+        provider: json
+        path: users.json  # Loads from /app/bodies/users.json
+```
+
+### Path Resolution Rules
+
+When a global folder is configured:
+
+1. **Relative paths** (e.g., `users.json`) → Combined with global folder
+2. **Absolute paths** (e.g., `/tmp/data.json`) → Global folder is ignored
+3. **URLs** (e.g., `https://...`) → Global folder is ignored
+
+```yaml
+- external-body:
+    folder: data/mocks
+
+- endpoint:
+    method: GET
+    path: /relative
+    response:
+      external-body:
+        provider: json
+        path: users.json  # ✅ Resolves to: data/mocks/users.json
+
+- endpoint:
+    method: GET
+    path: /absolute
+    response:
+      external-body:
+        provider: json
+        path: /tmp/users.json  # ✅ Uses absolute path as-is
+
+- endpoint:
+    method: GET
+    path: /remote
+    response:
+      external-body:
+        provider: json
+        path: https://api.example.com/users  # ✅ URL works as-is
+```
+
 ## 📄 JSON Provider
 
 ### Local File
@@ -415,6 +517,7 @@ curl http://localhost:8000/api/data?version=v2  # uses data/v2/response.json
 - ✅ Use meaningful file names (`users.json`, not `data1.json`)
 - ✅ Version control your data files alongside config
 - ✅ Use relative paths for portability
+- ✅ Use global configuration when all files are in the same folder
 - ✅ Document file structure in README
 
 **Don't:**

--- a/docs/how-to/deployment/docker.md
+++ b/docs/how-to/deployment/docker.md
@@ -253,6 +253,96 @@ docker-compose ps
 
 ---
 
+## External Bodies with Global Configuration
+
+When using external body files in Docker, you can leverage the global folder configuration to simplify your setup. This is especially useful when mounting volumes with response data.
+
+### Setup
+
+**1. Create directory structure:**
+
+```
+my-mock-project/
+├── docker-compose.yml
+├── moclojer.yml
+└── data/
+    ├── users.json
+    ├── products.json
+    └── orders.json
+```
+
+**2. Configure moclojer.yml with global folder:**
+
+```yaml
+# Global configuration for external bodies
+- external-body:
+    folder: /app/data
+
+# Endpoints use simple filenames
+- endpoint:
+    method: GET
+    path: /api/users
+    response:
+      status: 200
+      external-body:
+        provider: json
+        path: users.json  # Resolves to /app/data/users.json
+
+- endpoint:
+    method: GET
+    path: /api/products
+    response:
+      status: 200
+      external-body:
+        provider: json
+        path: products.json  # Resolves to /app/data/products.json
+```
+
+**3. docker-compose.yml:**
+
+```yaml
+services:
+  moclojer:
+    image: ghcr.io/moclojer/moclojer:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./moclojer.yml:/app/moclojer.yml:ro
+      - ./data:/app/data:ro  # Mount data directory
+    environment:
+      - PORT=8000
+      - HOST=0.0.0.0
+```
+
+**4. Run:**
+
+```bash
+docker-compose up
+```
+
+### Benefits
+
+✅ **Clean configuration**: No repeated paths
+✅ **Easy updates**: Update JSON files without changing config
+✅ **Volume management**: Single mount point for all data
+✅ **Team collaboration**: Clear separation between config and data
+
+### Testing
+
+```bash
+# Get users
+curl http://localhost:8000/api/users
+
+# Get products
+curl http://localhost:8000/api/products
+```
+
+### See Example
+
+Full working example available at: [`examples/external-body-global/`](https://github.com/moclojer/moclojer/tree/main/examples/external-body-global)
+
+---
+
 ## Multiple Environments
 
 ### File Structure

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -7,7 +7,10 @@
 
 ### Features
 
-* ...
+* Add global external-body folder configuration ([#328](https://github.com/moclojer/moclojer/issues/328))
+  - Configure a base folder for all external body files
+  - Reduces configuration duplication in Docker/Kubernetes deployments
+  - See [External Bodies documentation](../advanced/external-bodies.md#-global-configuration)
 
 ## Contributors
 

--- a/examples/external-body-global/README.md
+++ b/examples/external-body-global/README.md
@@ -1,0 +1,112 @@
+# External Body Global Configuration Example
+
+This example demonstrates how to use the global `external-body` folder configuration to avoid repeating paths across multiple endpoints.
+
+## Structure
+
+```
+external-body-global/
+├── config.yml           # Main configuration with global folder setting
+├── data/                # Base folder for all external bodies
+│   ├── users.json       # Users list
+│   ├── products.json    # Products list
+│   └── users/           # User details by ID
+│       └── 1.json
+└── README.md
+```
+
+## Benefits
+
+**Without global configuration:**
+
+```yaml
+- endpoint:
+    path: /api/users
+    response:
+      external-body:
+        provider: json
+        path: examples/external-body-global/data/users.json  # Full path
+
+- endpoint:
+    path: /api/products
+    response:
+      external-body:
+        provider: json
+        path: examples/external-body-global/data/products.json  # Repetitive!
+```
+
+**With global configuration:**
+
+```yaml
+# Set base folder once
+- external-body:
+    folder: examples/external-body-global/data
+
+# Use short filenames
+- endpoint:
+    path: /api/users
+    response:
+      external-body:
+        path: users.json  # Much cleaner!
+
+- endpoint:
+    path: /api/products
+    response:
+      external-body:
+        path: products.json  # No repetition!
+```
+
+## Running
+
+### Local (JAR or Binary)
+
+```bash
+# From project root with JAR
+CONFIG=$(pwd)/examples/external-body-global/config.yml java -jar moclojer.jar
+
+# Or with binary
+moclojer --config examples/external-body-global/config.yml
+
+# Or using environment variable
+CONFIG=examples/external-body-global/config.yml moclojer
+```
+
+### Docker
+
+```bash
+# Run with Docker (mounting both config and data)
+docker run -it \
+  -p 8000:8000 \
+  -v $(pwd)/examples/external-body-global/docker-config.yml:/app/moclojer.yml \
+  -v $(pwd)/examples/external-body-global/data:/config/data \
+  ghcr.io/moclojer/moclojer:latest
+```
+
+**Note:** The `docker-config.yml` uses absolute paths (`/config/data`) optimized for container environments, while `config.yml` uses relative paths for local development.
+
+## Testing
+
+```bash
+# Get all users
+curl http://localhost:8000/api/users
+
+# Get all products
+curl http://localhost:8000/api/products
+
+# Get user by ID (dynamic path)
+curl http://localhost:8000/api/users/1
+```
+
+## Use Cases
+
+This pattern is especially useful for:
+
+- **Docker/Kubernetes deployments** - Mount a volume and configure the base path once
+- **Multiple environments** - Change the folder path based on environment
+- **Clean configuration** - Reduce duplication and improve readability
+- **Team collaboration** - Easier to understand and maintain
+
+## See Also
+
+- [External Bodies Documentation](../../docs/advanced/external-bodies.md#-global-configuration)
+- [Docker Deployment Guide](../../docs/how-to/deployment/docker.md)

--- a/examples/external-body-global/config.yml
+++ b/examples/external-body-global/config.yml
@@ -1,0 +1,40 @@
+# Global external-body configuration example
+# This demonstrates how to use a base folder for all external body files
+
+# Configure global folder for all external bodies
+- external-body:
+    folder: examples/external-body-global/data
+
+# Endpoints using relative paths (will be combined with global folder)
+- endpoint:
+    method: GET
+    path: /api/users
+    response:
+      status: 200
+      headers:
+        Content-Type: application/json
+      external-body:
+        provider: json
+        path: users.json  # Resolves to: examples/external-body-global/data/users.json
+
+- endpoint:
+    method: GET
+    path: /api/products
+    response:
+      status: 200
+      headers:
+        Content-Type: application/json
+      external-body:
+        provider: json
+        path: products.json  # Resolves to: examples/external-body-global/data/products.json
+
+- endpoint:
+    method: GET
+    path: /api/users/:id
+    response:
+      status: 200
+      headers:
+        Content-Type: application/json
+      external-body:
+        provider: json
+        path: users/{{path-params.id}}.json  # Dynamic path

--- a/examples/external-body-global/data/products.json
+++ b/examples/external-body-global/data/products.json
@@ -1,0 +1,23 @@
+{
+  "products": [
+    {
+      "id": 101,
+      "name": "Laptop",
+      "price": 1299.99,
+      "category": "Electronics"
+    },
+    {
+      "id": 102,
+      "name": "Coffee Maker",
+      "price": 79.99,
+      "category": "Home & Kitchen"
+    },
+    {
+      "id": 103,
+      "name": "Running Shoes",
+      "price": 129.99,
+      "category": "Sports"
+    }
+  ],
+  "total": 3
+}

--- a/examples/external-body-global/data/users.json
+++ b/examples/external-body-global/data/users.json
@@ -1,0 +1,23 @@
+{
+  "users": [
+    {
+      "id": 1,
+      "name": "Alice Johnson",
+      "email": "alice@example.com",
+      "role": "admin"
+    },
+    {
+      "id": 2,
+      "name": "Bob Smith",
+      "email": "bob@example.com",
+      "role": "user"
+    },
+    {
+      "id": 3,
+      "name": "Charlie Brown",
+      "email": "charlie@example.com",
+      "role": "user"
+    }
+  ],
+  "total": 3
+}

--- a/examples/external-body-global/data/users/1.json
+++ b/examples/external-body-global/data/users/1.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "name": "Alice Johnson",
+  "email": "alice@example.com",
+  "role": "admin",
+  "createdAt": "2024-01-15",
+  "lastLogin": "2025-12-22",
+  "preferences": {
+    "theme": "dark",
+    "notifications": true
+  }
+}

--- a/examples/external-body-global/docker-compose.yml
+++ b/examples/external-body-global/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  moclojer:
+    image: moclojer:test  # Use ghcr.io/moclojer/moclojer:latest in production
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./docker-config.yml:/app/moclojer.yml
+      - ./data:/config/data
+    environment:
+      - PORT=8000
+      - HOST=0.0.0.0
+    # The entrypoint uses CONFIG env var by default pointing to /app/moclojer.yml

--- a/examples/external-body-global/docker-config.yml
+++ b/examples/external-body-global/docker-config.yml
@@ -1,0 +1,39 @@
+# Docker-specific configuration with absolute paths
+
+# Configure global folder for all external bodies
+- external-body:
+    folder: /config/data
+
+# Endpoints using relative paths (will be combined with global folder)
+- endpoint:
+    method: GET
+    path: /api/users
+    response:
+      status: 200
+      headers:
+        Content-Type: application/json
+      external-body:
+        provider: json
+        path: users.json  # Resolves to: /config/data/users.json
+
+- endpoint:
+    method: GET
+    path: /api/products
+    response:
+      status: 200
+      headers:
+        Content-Type: application/json
+      external-body:
+        provider: json
+        path: products.json  # Resolves to: /config/data/products.json
+
+- endpoint:
+    method: GET
+    path: /api/users/:id
+    response:
+      status: 200
+      headers:
+        Content-Type: application/json
+      external-body:
+        provider: json
+        path: users/{{path-params.id}}.json  # Dynamic path

--- a/src/com/moclojer/specs/moclojer.clj
+++ b/src/com/moclojer/specs/moclojer.clj
@@ -35,10 +35,14 @@
        :content (json/write-str {:message (.getMessage e)})})))
 
 (defn enrich-external-body
-  "Enriches the external body with a resolved path."
-  [external-body request]
-  (let [{:keys [content]} (render-template (:path external-body) request)]
-    (assoc external-body :path content)))
+  "Enriches the external body with a resolved path.
+   If global-folder is provided, prepends it to the path."
+  [external-body request & [global-folder]]
+  (let [{:keys [content]} (render-template (:path external-body) request)
+        final-path (if (and global-folder (not (string/starts-with? content "/")))
+                     (str global-folder "/" content)
+                     content)]
+    (assoc external-body :path final-path)))
 
 (defn parse-json-safely
   "Tries to parse a JSON, returning the original content in case of error"
@@ -53,19 +57,19 @@
 
 (defn get-response-body
   "Gets the correct response body (processing external-body if necessary)"
-  [response request]
+  [response request & [global-folder]]
   (if-let [?external-body (:external-body response)]
     (-> ?external-body
-        (enrich-external-body request)
+        (enrich-external-body request global-folder)
         ext-body/type-identification)
     (:body response)))
 
 (defn build-body
   "Builds the body from the response."
-  [response request]
+  [response request & [global-folder]]
   (try
     (let [{:keys [content error?]} (-> response
-                                       (get-response-body request)
+                                       (get-response-body request global-folder)
                                        (render-template request))]
       (cond
         error?
@@ -130,8 +134,9 @@
 (defn generic-reitit-handler
   "Builds a reitit handler that responds with pre-defined `response`.
    Since we also support `webhooks`, given `webhook-config` is used
-   when necessary in together with the `response`."
-  [response webhook-config]
+   when necessary in together with the `response`.
+   Accepts optional `global-folder` for external-body path resolution."
+  [response webhook-config & [global-folder]]
   (fn [request]
     (when webhook-config
       (webhook/request-after-delay
@@ -150,7 +155,7 @@
                      (:headers request))
         :sleep-time (:sleep-time webhook-config)}))
     (let [parameters (build-parameters (:parameters request))
-          body-result (build-body response parameters)]
+          body-result (build-body response parameters global-folder)]
       (log/log :info :body body-result)
       (if (and (map? body-result) (:error body-result))
         {:body (json/write-str body-result)
@@ -253,33 +258,35 @@
                  :message (.getMessage e))))))
 
 (defn process-http-routes
-  "Process HTTP endpoints and return route configurations"
-  [spec]
-  (for [[[host path method tag] endpoints]
-        (group-by (juxt :host :path #(generate-method (:method %)) :tag)
-                  (remove nil? (map :endpoint (filter #(contains? % :endpoint) spec))))]
-    (let [method (generate-method method)
-          route-name (generate-route-name host path method)
-          endpoint (first endpoints)
-          response (:response endpoint)
-          real-path (create-url path)
-          rate-limit (:rate-limit endpoint)
-          create-params-fn #(create-swagger-parameters
-                             (make-path-parameters path %)
-                             (make-query-parameters (:query endpoint) %)
-                             (make-body (:body endpoint) :request))]
-      [real-path
-       {:data {:host (or host "localhost")
-               :rate-limit rate-limit}
-        (keyword method)
-        {:summary (if-not (string/blank? real-path)
-                    (str "Generated from " real-path)
-                    "Auto-generated")
-         :swagger {:tags [(or tag route-name)]}
-         :parameters (create-params-fn true)
-         :responses {(or (:status response) 200)
-                     {:body any?}}
-         :handler (generic-reitit-handler response nil)}}])))
+  "Process HTTP endpoints and return route configurations.
+   Accepts optional global-config with external-body folder configuration."
+  [spec & [global-config]]
+  (let [global-folder (get-in global-config [:external-body :folder])]
+    (for [[[host path method tag] endpoints]
+          (group-by (juxt :host :path #(generate-method (:method %)) :tag)
+                    (remove nil? (map :endpoint (filter #(contains? % :endpoint) spec))))]
+      (let [method (generate-method method)
+            route-name (generate-route-name host path method)
+            endpoint (first endpoints)
+            response (:response endpoint)
+            real-path (create-url path)
+            rate-limit (:rate-limit endpoint)
+            create-params-fn #(create-swagger-parameters
+                               (make-path-parameters path %)
+                               (make-query-parameters (:query endpoint) %)
+                               (make-body (:body endpoint) :request))]
+        [real-path
+         {:data {:host (or host "localhost")
+                 :rate-limit rate-limit}
+          (keyword method)
+          {:summary (if-not (string/blank? real-path)
+                      (str "Generated from " real-path)
+                      "Auto-generated")
+           :swagger {:tags [(or tag route-name)]}
+           :parameters (create-params-fn true)
+           :responses {(or (:status response) 200)
+                       {:body any?}}
+           :handler (generic-reitit-handler response nil global-folder)}}]))))
 
 (defn create-ws-handler
   "Create WebSocket handler function with connection and message handling"
@@ -344,9 +351,16 @@
 (defn ->reitit
   "Adapts given moclojer endpoints to reitit's data based routes, while
    parsing request data types throughout the way. Supports both HTTP endpoints
-   and WebSocket endpoints."
+   and WebSocket endpoints.
+
+   Supports global configuration via special keys (e.g., :external-body)."
   [spec]
-  (let [http-routes (process-http-routes spec)
+  (let [;; Extract global configuration (items with :external-body key but no :endpoint/:websocket)
+        global-config (first (filter #(and (contains? % :external-body)
+                                           (not (contains? % :endpoint))
+                                           (not (contains? % :websocket)))
+                                     spec))
+        http-routes (process-http-routes spec global-config)
         ws-routes (process-ws-routes spec)
         swagger-route (create-swagger-route)
         all-routes (concat http-routes ws-routes swagger-route)]

--- a/test/com/moclojer/external_body/core_test.clj
+++ b/test/com/moclojer/external_body/core_test.clj
@@ -46,3 +46,17 @@
                    (:status (server {:request-method :get
                                      :uri (str "/pokemon/" name)})))
       ["kabuto" "marowak"])))
+
+(deftest global-folder-config-test
+  (testing "global external-body folder configuration"
+    (let [server (helpers/service-fn
+                  "test/com/moclojer/resources/external-body-global-config.yml")]
+      (testing "endpoint using global folder"
+        (is (= (jsond/write-str ret-text)
+               (:body (server {:request-method :get
+                               :uri "/with-global-folder"})))))
+
+      (testing "endpoint without external-body is not affected by global config"
+        (is (= "{\"msg\":\"hello world\"}"
+               (:body (server {:request-method :get
+                               :uri "/without-external-body"}))))))))

--- a/test/com/moclojer/resources/external-body-global-config.yml
+++ b/test/com/moclojer/resources/external-body-global-config.yml
@@ -1,0 +1,24 @@
+# Global configuration (as list item)
+- external-body:
+    folder: test/com/moclojer/resources
+
+# Endpoints
+- endpoint:
+    method: GET
+    path: /with-global-folder
+    response:
+      status: 200
+      headers:
+        Content-Type: application/json
+      external-body:
+        provider: json
+        path: text-plan.json
+
+- endpoint:
+    method: GET
+    path: /without-external-body
+    response:
+      status: 200
+      headers:
+        Content-Type: application/json
+      body: '{"msg": "hello world"}'

--- a/test/com/moclojer/specs/moclojer_test.clj
+++ b/test/com/moclojer/specs/moclojer_test.clj
@@ -84,7 +84,7 @@
 
   (testing "handles external body"
     (let [response {:external-body {:path "/some/path" :content "external content"}}
-          enrich-mock (fn [body _] body)
+          enrich-mock (fn [body _ & _] body)
           type-mock (fn [body] (assoc body :content "processed content"))
           render-mock (fn [_ _] {:content "processed content"})
           result (with-redefs [render-template render-mock


### PR DESCRIPTION
Docker deployments with mounted volumes required repeating the full folder path in every endpoint's external-body configuration. This created unnecessary duplication and made configs harder to maintain, especially in Kubernetes/Docker Compose setups where data is mounted to a known location.

Implemented global folder configuration that allows setting a base directory once. The router now extracts global config items (identified by having an :external-body key without :endpoint or :websocket), passes the folder path through the handler creation chain, and combines it with relative paths at request time. Absolute paths and URLs bypass the global folder to maintain backward compatibility.

Configuration example:

```yaml
- external-body:
    folder: /app/data

- endpoint:
    method: GET
    path: /api/users
    response:
      external-body:
        provider: json
        path: users.json  # Resolves to /app/data/users.json
```

Path resolution rules:
- Relative paths (e.g., users.json) → Combined with global folder
- Absolute paths (e.g., /tmp/data.json) → Global folder ignored
- URLs (e.g., https://...) → Global folder ignored

The implementation threads the global folder through the call chain: ->reitit extracts it from spec, process-http-routes receives it as optional parameter, generic-reitit-handler closes over it, and enrich-external-body applies it before file resolution. This keeps the change localized to the specs/moclojer namespace without touching external-body providers.

Added comprehensive tests covering relative paths with global folder, endpoints without external-body, and full paths that should ignore the global config. All 40 existing tests continue passing.

Created a complete working example in examples/external-body-global/ with both local and Docker configurations, demonstrating the Docker use case with docker-compose setup. Updated documentation in external-bodies.md with global configuration section and added Docker deployment guide showing volume mounting pattern.

Closes #328